### PR TITLE
HPTT for TensorViews

### DIFF
--- a/libs/Einsums/HPTT/include/Einsums/HPTT/ComputeNode.hpp
+++ b/libs/Einsums/HPTT/include/Einsums/HPTT/ComputeNode.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <limits>
 
 namespace hptt {
 
@@ -10,18 +11,21 @@ namespace hptt {
 class ComputeNode {
 public:
   ComputeNode()
-      : start(-1), end(-1), inc(-1), lda(-1), ldb(-1), next(nullptr) {}
+      : start(-1), end(-1), inc(-1), lda(-1), ldb(-1), indexA(false), indexB(false), offDiffAB(std::numeric_limits<int>::min()), next(nullptr) {}
 
   ~ComputeNode() {
     if (next != nullptr)
       delete next;
   }
 
-  size_t start; //!< start index for at the current loop
-  size_t end;   //!< end index for at the current loop
-  size_t inc;   //!< increment for at the current loop
-  size_t lda;   //!< stride of A w.r.t. the loop index
-  size_t ldb;   //!< stride of B w.r.t. the loop index
+  size_t start;     //!< start index for at the current loop
+  size_t end;       //!< end index for at the current loop
+  size_t inc;       //!< increment for at the current loop
+  size_t lda;       //!< stride of A w.r.t. the loop index
+  size_t ldb;       //!< stride of B w.r.t. the loop index
+  bool   indexA;    //!< true if index of A is innermost (0)
+  bool   indexB;    //!< true if index of B is innermost (0)
+  int    offDiffAB; //!< difference in offset A and B (i.e., A - B) at the current loop
   ComputeNode
       *next; //!< next ComputeNode, this might be another loop or 'nullptr'
              //!< (i.e., indicating that the macro-kernel should be called)

--- a/libs/Einsums/HPTT/include/Einsums/HPTT/HPTT.hpp
+++ b/libs/Einsums/HPTT/include/Einsums/HPTT/HPTT.hpp
@@ -342,8 +342,258 @@ std::shared_ptr<hptt::Transpose<DoubleComplex>> create_plan(int const *perm, int
                                                             DoubleComplex const beta, DoubleComplex *B, int const *outerSizeB,
                                                             int const maxAutotuningCandidates, int const numThreads,
                                                             int const *threadIds = nullptr, bool const useRowMajor = false);
-} // namespace hptt
 
+/**
+ * \brief Creates a Tensor Transposition plan
+ *
+ * A tensor transposition plan is a data structure that encodes the execution of
+ * the tensor transposition. HPTT supports tensor transpositions of the form:
+ * \f[ B_{\pi(i_0,i_1,...)} = \alpha * A_{i_0,i_1,...} + \beta *
+ * B_{\pi(i_0,i_1,...)}. \f] The plan can be reused over several transpositions.
+ *
+ * \param[in] perm dim-dimensional array representing the permutation of the
+ * indices.
+ *                 * For instance, perm[] = {1,0,2} denotes the following
+ * transposition: \f$B_{i1,i0,i2} \gets A_{i0,i1,i2}\f$. \param[in] dim
+ * Dimensionality of the tensors \param[in] alpha scaling factor for A
+ * \param[in] A Pointer to the raw-data of the input tensor A
+ * \param[in] sizeA dim-dimensional array that stores the sizes of each
+ * dimension of A \param[in] outerSizeA dim-dimensional array that stores the
+ * outer-sizes of each dimension of A.
+ *                       * This parameter may be NULL, indicating that the
+ * outer-size is equal to sizeA.
+ *                       * If outerSizeA is not NULL, outerSizeA[i] >= sizeA[i]
+ * for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on sub-tensors.
+ * \param[in] offsetA dim-dimensional array that stores the offsets in each 
+ * dimension of A 
+ *                       * This parameter may be NULL, indicating that the 
+ * offset is zero.
+ *                       * If offsetA is not NULL, outerSizeA[i] >= offsetA[i]
+ *  + sizeA[i] >= 0 for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on intermediate 
+ * sub-tensors.
+ * \param[in] beta scaling factor for B
+ * \param[inout] B Pointer to the raw-data of the output tensor B
+ * \param[in] outerSizeB dim-dimensional array that stores the outer-sizes of
+ * each dimension of B.
+ *                       * This parameter may be NULL, indicating that the
+ * outer-size is equal to the perm(sizeA).
+ *                       * If outerSizeA is not NULL, outerSizeB[i] >=
+ * perm(sizeA)[i] for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on sub-tensors.
+ * \param[in] offsetB dim-dimensional array that stores the offsets in each 
+ * dimension of B
+ *                       * This parameter may be NULL, indicating that the 
+ * offset is zero.
+ *                       * If offsetB is not NULL, outerSizeB[i] >= offsetB[i] 
+ * + sizeB[i] >= 0 for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on intermediate 
+ * sub-tensors.
+ * \param[in] selectionMethod Determines if auto-tuning should be used. See
+ * hptt::SelectionMethod for details. ATTENTION: If you enable auto-tuning
+ * (e.g., hptt::MEASURE) then the output data will be used during the
+ *                            auto-tuning process. The original data (i.e., A
+ * and B), however, is preserved after this function call completes -- unless
+ * your input data (i.e. A) has invalid data (e.g., NaN, inf). \param[in]
+ * numThreads number of threads that participate in this tensor transposition.
+ * \param[in] threadIds Array of OpenMP threadIds that participate in this
+ *            tensor transposition. This parameter is only important if you want
+ * to call HPTT from within a parallel region (i.e., via execute_expert()).
+ * \param[in] useRowMajor This flag indicates whether a row-major memory layout
+ * should be used (default: off = column-major).
+ */
+/* Methods with (floats, doubles, FloatComplexes, and DoubleComplexes) (alpha, A, beta, and B), SelectionMethod Class,
+ * --int-- Offsets, and --ints-- (sizeA, outerSizeA, and outerSizeB). */
+/**
+ * @copydoc create_plan(const int *,const int,const float,const float *,const int *,const int *,const int *,const float,float *,
+ *  const int *,const int *,const SelectionMethod,const int,const int *,const bool)
+ */
+std::shared_ptr<hptt::Transpose<float> > create_plan( const int *perm, const int dim,
+                 const float alpha, const float *A, const int *sizeA, const int *outerSizeA, const int *offsetA, 
+                 const float beta, float *B, const int *outerSizeB, const int *offsetB,
+                 const SelectionMethod selectionMethod,
+                 const int numThreads, const int *threadIds = nullptr, const bool useRowMajor = false);
+
+/**
+ * @copydoc create_plan(const int *,const int,const double,const double *,const int *,const int *,const int *,const double,double *,
+ *  const int *,const int *,const SelectionMethod,const int,const int *,const bool)
+ */
+std::shared_ptr<hptt::Transpose<double> > create_plan( const int *perm, const int dim,
+                 const double alpha, const double *A, const int *sizeA, const int *outerSizeA, 
+                 const double beta, double *B, const int *outerSizeB, const int *offsetB,
+                 const SelectionMethod selectionMethod,
+                 const int numThreads, const int *threadIds = nullptr, const bool useRowMajor = false);
+
+/**
+ * @copydoc create_plan(const int *,const int,const FloatComplex,const FloatComplex *,const int *,const int *,const int *,const 
+ *  FloatComplex,FloatComplex *,const int *,const int *,const SelectionMethod,const int,const int *,const bool)
+ */
+std::shared_ptr<hptt::Transpose<FloatComplex> > create_plan( const int *perm, const int dim,
+                 const FloatComplex alpha, const FloatComplex *A, const int *sizeA, const int *outerSizeA, const int *offsetA, 
+                 const FloatComplex beta, FloatComplex *B, const int *outerSizeB, const int *offsetB, 
+                 const SelectionMethod selectionMethod,
+                 const int numThreads, const int *threadIds = nullptr, const bool useRowMajor = false);
+
+/**
+ * @copydoc create_plan(const int *,const int,const DoubleComplex,const DoubleComplex *,const int *,const int *,const int *,const 
+ *  DoubleComplex,DoubleComplex *,const int *,const int *,const SelectionMethod,const int,const int *,const bool)
+ */
+std::shared_ptr<hptt::Transpose<DoubleComplex> > create_plan( const int *perm, const int dim,
+                 const DoubleComplex alpha, const DoubleComplex *A, const int *sizeA, const int *outerSizeA, const int *offsetA, 
+                 const DoubleComplex beta, DoubleComplex *B, const int *outerSizeB, const int *offsetB,
+                 const SelectionMethod selectionMethod,
+                 const int numThreads, const int *threadIds = nullptr, const bool useRowMajor = false);
+
+/* Methods with (floats, doubles, FloatComplexes, and DoubleComplexes) (alpha, A, beta, and B), SelectionMethod Class,
+ * --vector int-- Offsets, and --vector ints-- (sizeA, outerSizeA, and outerSizeB). */
+/**
+ * @copydoc create_plan(const std::vector<int> &,const int,const float,const float *,const std::vector<int> &,const std::vector<int> 
+ *  &,const std::vector<int> &,const float,float *,const std::vector<int> &,const std::vector<int> &,const SelectionMethod,const int,
+ *  const std::vector<int> &,const bool)
+ */
+std::shared_ptr<hptt::Transpose<float> > create_plan( const std::vector<int> &perm, const int dim,
+                 const float alpha, const float *A, const std::vector<int> &sizeA, const std::vector<int> &outerSizeA, const std::vector<int> &offsetA,
+                 const float beta, float *B, const std::vector<int> &outerSizeB, const std::vector<int> &offsetB,
+                 const SelectionMethod selectionMethod,
+                 const int numThreads, const std::vector<int> &threadIds = {}, const bool useRowMajor = false);
+
+/**
+ * @copydoc create_plan(const std::vector<int> &,const int,const double,const double *,const std::vector<int> &,const std::vector<int> 
+ *  &,const std::vector<int> &,const double,double *,const std::vector<int> &,const std::vector<int> &,const SelectionMethod,const int,
+ *  const std::vector<int> &,const bool)
+ */
+std::shared_ptr<hptt::Transpose<double> > create_plan( const std::vector<int> &perm, const int dim,
+                 const double alpha, const double *A, const std::vector<int> &sizeA, const std::vector<int> &outerSizeA, const std::vector<int> &offsetA,
+                 const double beta, double *B, const std::vector<int> &outerSizeB, const std::vector<int> &offsetB,
+                 const SelectionMethod selectionMethod,
+                 const int numThreads, const std::vector<int> &threadIds = {}, const bool useRowMajor = false);
+
+/**
+ * @copydoc create_plan(const std::vector<int> &,const int,const FloatComplex,const FloatComplex *,const std::vector<int> &,const 
+ *  std::vector<int> &,const std::vector<int> &,const FloatComplex,FloatComplex *,const std::vector<int> &,const std::vector<int> &,
+ *  const SelectionMethod,const int,const std::vector<int> &,const bool)
+ */
+std::shared_ptr<hptt::Transpose<FloatComplex> > create_plan( const std::vector<int> &perm, const int dim,
+                 const FloatComplex alpha, const FloatComplex *A, const std::vector<int> &sizeA, const std::vector<int> &outerSizeA, const std::vector<int> &offsetA,
+                 const FloatComplex beta, FloatComplex *B, const std::vector<int> &outerSizeB, const std::vector<int> &offsetB,
+                 const SelectionMethod selectionMethod,
+                 const int numThreads, const std::vector<int> &threadIds = {}, const bool useRowMajor = false);
+
+/**
+ * @copydoc create_plan(const std::vector<int> &,const int,const DoubleComplex,const DoubleComplex *,const std::vector<int> &,const 
+ *  std::vector<int> &,const std::vector<int> &,const DoubleComplex,DoubleComplex *,const std::vector<int> &,const std::vector<int> 
+ *  &,const SelectionMethod,const int,const std::vector<int> &,const bool)
+ */
+std::shared_ptr<hptt::Transpose<DoubleComplex> > create_plan( const std::vector<int> &perm, const int dim,
+                 const DoubleComplex alpha, const DoubleComplex *A, const std::vector<int> &sizeA, const std::vector<int> &outerSizeA, const std::vector<int> &offsetA,
+                 const DoubleComplex beta, DoubleComplex *B, const std::vector<int> &outerSizeB, const std::vector<int> &offsetB,
+                 const SelectionMethod selectionMethod,
+                 const int numThreads, const std::vector<int> &threadIds = {}, const bool useRowMajor = false);
+
+/**
+ * \brief Creates a Tensor Transposition plan
+ *
+ * A tensor transposition plan is a data structure that encodes the execution of
+ * the tensor transposition. HPTT supports tensor transpositions of the form:
+ * \f[ B_{\pi(i_0,i_1,...)} = \alpha * A_{i_0,i_1,...} + \beta *
+ * B_{\pi(i_0,i_1,...)}. \f] The plan can be reused over several transpositions.
+ *
+ * \param[in] perm dim-dimensional array representing the permutation of the
+ * indices.
+ *                 * For instance, perm[] = {1,0,2} denotes the following
+ * transposition: \f$B_{i1,i0,i2} \gets A_{i0,i1,i2}\f$. \param[in] dim
+ * Dimensionality of the tensors \param[in] alpha scaling factor for A
+ * \param[in] A Pointer to the raw-data of the input tensor A
+ * \param[in] sizeA dim-dimensional array that stores the sizes of each
+ * dimension of A \param[in] outerSizeA dim-dimensional array that stores the
+ * outer-sizes of each dimension of A.
+ *                       * This parameter may be NULL, indicating that the
+ * outer-size is equal to sizeA.
+ *                       * If outerSizeA is not NULL, outerSizeA[i] >= sizeA[i]
+ * for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on sub-tensors.
+ * \param[in] offsetA dim-dimensional array that stores the offsets in each 
+ * dimension of A 
+ *                       * This parameter may be NULL, indicating that the 
+ * offset is zero.
+ *                       * If offsetA is not NULL, outerSizeA[i] >= offsetA[i]
+ *  + sizeA[i] >= 0 for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on intermediate 
+ * sub-tensors.
+ * \param[in] beta scaling factor for B
+ * \param[inout] B Pointer to the raw-data of the output tensor B
+ * \param[in] outerSizeB dim-dimensional array that stores the outer-sizes of
+ * each dimension of B.
+ *                       * This parameter may be NULL, indicating that the
+ * outer-size is equal to the perm(sizeA).
+ *                       * If outerSizeA is not NULL, outerSizeB[i] >=
+ * perm(sizeA)[i] for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on sub-tensors.
+ * \param[in] offsetB dim-dimensional array that stores the offsets in each 
+ * dimension of B
+ *                       * This parameter may be NULL, indicating that the 
+ * offset is zero.
+ *                       * If offsetB is not NULL, outerSizeB[i] >= offsetB[i] 
+ * + sizeB[i] >= 0 for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on intermediate 
+ * sub-tensors.
+ * \param[in] selectionMethod Determines if auto-tuning should be used. See
+ * hptt::SelectionMethod for details. ATTENTION: If you enable auto-tuning
+ * (e.g., hptt::MEASURE) then the output data will be used during the
+ *                            auto-tuning process. The original data (i.e., A
+ * and B), however, is preserved after this function call completes -- unless
+ * your input data (i.e. A) has invalid data (e.g., NaN, inf). \param[in]
+ * numThreads number of threads that participate in this tensor transposition.
+ * \param[in] threadIds Array of OpenMP threadIds that participate in this
+ *            tensor transposition. This parameter is only important if you want
+ * to call HPTT from within a parallel region (i.e., via execute_expert()).
+ * \param[in] useRowMajor This flag indicates whether a row-major memory layout
+ * should be used (default: off = column-major).
+ */
+
+/* Methods with (floats, doubles, FloatComplexes, and DoubleComplexes) (alpha, A, beta, and B), --int-- maxAutotuningCandidates, 
+ * --int-- Offsets, and ints (sizeA, outerSizeA, and outerSizeB). */
+/**
+ * @copydoc create_plan(const int *,const int,const float,const float *,const int *,const int *,const int *,const float,float *,
+ *  const int *,const int *,const int,const int,const int *,const bool)
+ */
+std::shared_ptr<hptt::Transpose<float> > create_plan( const int *perm, const int dim,
+                 const float alpha, const float *A, const int *sizeA, const int *outerSizeA, const int *offsetA, 
+                 const float beta, float *B, const int *outerSizeB, const int *offsetB, 
+                 const int maxAutotuningCandidates,
+                 const int numThreads, const int *threadIds = nullptr, const bool useRowMajor = false);
+
+/**
+ * @copydoc create_plan(const int *,const int,const double,const double *,const int *,const int *,const int *,const double,double *,
+ *  const int *,const int *,const int,const int,const int *,const bool)
+ */
+std::shared_ptr<hptt::Transpose<double> > create_plan( const int *perm, const int dim,
+                 const double alpha, const double *A, const int *sizeA, const int *outerSizeA, const int *offsetA, 
+                 const double beta, double *B, const int *outerSizeB, const int *offsetB, 
+                 const int maxAutotuningCandidates,
+                 const int numThreads, const int *threadIds = nullptr, const bool useRowMajor = false);
+
+/**
+ * @copydoc create_plan(const int *,const int,const FloatComplex,const FloatComplex *,const int *,const int *,const int *,const 
+ *  FloatComplex,FloatComplex *,const int *,const int *,const int,const int,const int *,const bool)
+ */
+std::shared_ptr<hptt::Transpose<FloatComplex> > create_plan( const int *perm, const int dim,
+                 const FloatComplex alpha, const FloatComplex *A, const int *sizeA, const int *outerSizeA, const int *offsetA, 
+                 const FloatComplex beta, FloatComplex *B, const int *outerSizeB, const int *offsetB, 
+                 const int maxAutotuningCandidates,
+                 const int numThreads, const int *threadIds = nullptr, const bool useRowMajor = false);
+
+/**
+ * @copydoc create_plan(const int *,const int,const DoubleComplex,const DoubleComplex *,const int *,const int *,const int *,const 
+ *  DoubleComplex,DoubleComplex *,const int *,const int *,const int,const int,const int *,const bool)
+ */
+std::shared_ptr<hptt::Transpose<DoubleComplex> > create_plan( const int *perm, const int dim,
+                 const DoubleComplex alpha, const DoubleComplex *A, const int *sizeA, const int *outerSizeA, const int *offsetA, 
+                 const DoubleComplex beta, DoubleComplex *B, const int *outerSizeB, const int *offsetB, 
+                 const int maxAutotuningCandidates,
+                 const int numThreads, const int *threadIds = nullptr, const bool useRowMajor = false);
+} // namespace hptt
 // extern "C"
 // {
 /**
@@ -434,4 +684,136 @@ void cTensorTranspose(int const *perm, int const dim, _Complex float const alpha
 void zTensorTranspose(int const *perm, int const dim, _Complex double const alpha, bool conjA, _Complex double const *A, int const *sizeA,
                       int const *outerSizeA, _Complex double const beta, _Complex double *B, int const *outerSizeB, int const numThreads,
                       int const useRowMajor = 0);
+
+/**
+ * \brief Computes the out-of-place tensor transposition of A into B
+ *
+ * A tensor transposition plan is a data structure that encodes the execution of
+ * the tensor transposition. HPTT supports tensor transpositions of the form:
+ * \f[ B_{\pi(i_0,i_1,...)} = \alpha * A_{i_0,i_1,...} + \beta *
+ * B_{\pi(i_0,i_1,...)}. \f] The plan can be reused over several transpositions.
+ *
+ * \param[in] perm dim-dimensional array representing the permutation of the
+ * indices.
+ *                 * For instance, perm[] = {1,0,2} denotes the following
+ * transposition: \f$B_{i1,i0,i2} \gets A_{i0,i1,i2}\f$. \param[in] dim
+ * Dimensionality of the tensors \param[in] alpha scaling factor for A
+ * \param[in] A Pointer to the raw-data of the input tensor A
+ * \param[in] sizeA dim-dimensional array that stores the sizes of each
+ * dimension of A \param[in] outerSizeA dim-dimensional array that stores the
+ * outer-sizes of each dimension of A.
+ *                       * This parameter may be NULL, indicating that the
+ * outer-size is equal to sizeA.
+ *                       * If outerSizeA is not NULL, outerSizeA[i] >= sizeA[i]
+ * for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on sub-tensors.
+ * \param[in] offsetA dim-dimensional array that stores the offsets in each 
+ * dimension of A 
+ *                       * This parameter may be NULL, indicating that the 
+ * offset is zero.
+ *                       * If offsetA is not NULL, outerSizeA[i] >= offsetA[i]
+ *  + sizeA[i] >= 0 for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on intermediate 
+ * sub-tensors.
+ * \param[in] beta scaling factor for B
+ * \param[inout] B Pointer to the raw-data of the output tensor B
+ * \param[in] outerSizeB dim-dimensional array that stores the outer-sizes of
+ * each dimension of B.
+ *                       * This parameter may be NULL, indicating that the
+ * outer-size is equal to the perm(sizeA).
+ *                       * If outerSizeA is not NULL, outerSizeB[i] >=
+ * perm(sizeA)[i] for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on sub-tensors.
+ * \param[in] offsetB dim-dimensional array that stores the offsets in each 
+ * dimension of B 
+ *                       * This parameter may be NULL, indicating that the 
+ * offset is zero.
+ *                       * If offsetB is not NULL, outerSizeB[i] >= offsetB[i]
+ *  + sizeA[i] >= 0 for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on intermediate 
+ * sub-tensors.
+ * \param[in] numThreads number of threads that participate in this tensor
+ * transposition. \param[in] useRowMajor This flag indicates whether a row-major
+ * memory layout should be used (default: off = column-major).
+ */
+
+/// @copydoc sTensorTranspose(const int *,const int,const float,const float *,const int *,const int *,const int *,const float,float *,
+/// const int *,const int *,const int,const int)
+void sOffsetTensorTranspose( const int *perm, const int dim,
+                 const float alpha, const float *A, const int *sizeA, const int *outerSizeA, const int *offsetA,
+                 const float beta,        float *B,                   const int *outerSizeB, const int *offsetB,
+                 const int numThreads, const int useRowMajor = 0);
+
+/// @copydoc dTensorTranspose(const int *,const int,const float,const float *,const int *,const int *,const int *,const float,float *,
+/// const int *,const int *,const int,const int)
+void dOffsetTensorTranspose( const int *perm, const int dim,
+                 const double alpha, const double *A, const int *sizeA, const int *outerSizeA, const int *offsetA,
+                 const double beta,        double *B,                   const int *outerSizeB, const int *offsetB,
+                 const int numThreads, const int useRowMajor = 0);
+
+/**
+ * \brief Computes the out-of-place tensor transposition of A into B
+ *
+ * A tensor transposition plan is a data structure that encodes the execution of
+ * the tensor transposition. HPTT supports tensor transpositions of the form:
+ * \f[ B_{\pi(i_0,i_1,...)} = \alpha * A_{i_0,i_1,...} + \beta *
+ * B_{\pi(i_0,i_1,...)}. \f] The plan can be reused over several transpositions.
+ *
+ * \param[in] perm dim-dimensional array representing the permutation of the
+ * indices.
+ *                 * For instance, perm[] = {1,0,2} denotes the following
+ * transposition: \f$B_{i1,i0,i2} \gets A_{i0,i1,i2}\f$. \param[in] dim
+ * Dimensionality of the tensors \param[in] alpha scaling factor for A
+ * @param[in] conjA Whether to conjugate A.
+ * \param[in] A Pointer to the raw-data of the input tensor A
+ * \param[in] sizeA dim-dimensional array that stores the sizes of each
+ * dimension of A \param[in] outerSizeA dim-dimensional array that stores the
+ * outer-sizes of each dimension of A.
+ *                       * This parameter may be NULL, indicating that the
+ * outer-size is equal to sizeA.
+ *                       * If outerSizeA is not NULL, outerSizeA[i] >= sizeA[i]
+ * for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on sub-tensors.
+ * \param[in] offsetA dim-dimensional array that stores the offsets in each 
+ * dimension of A 
+ *                       * This parameter may be NULL, indicating that the 
+ * offset is zero.
+ *                       * If offsetA is not NULL, outerSizeA[i] >= offsetA[i]
+ *  + sizeA[i] >= 0 for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on intermediate 
+ * sub-tensors.
+ * \param[in] beta scaling factor for B
+ * \param[inout] B Pointer to the raw-data of the output tensor B
+ * \param[in] outerSizeB dim-dimensional array that stores the outer-sizes of
+ * each dimension of B.
+ *                       * This parameter may be NULL, indicating that the
+ * outer-size is equal to the perm(sizeA).
+ *                       * If outerSizeA is not NULL, outerSizeB[i] >=
+ * perm(sizeA)[i] for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on sub-tensors.
+ * \param[in] offsetB dim-dimensional array that stores the offsets in each 
+ * dimension of B 
+ *                       * This parameter may be NULL, indicating that the 
+ * offset is zero.
+ *                       * If offsetB is not NULL, outerSizeB[i] >= offsetB[i]
+ *  + sizeB[i] >= 0 for all 0 <= i < dim must hold.
+ *                       * This option enables HPTT to operate on intermediate 
+ * sub-tensors.
+ * \param[in] numThreads number of threads that participate in this tensor
+ * transposition. \param[in] useRowMajor This flag indicates whether a row-major
+ * memory layout should be used (default: off = column-major).
+ */
+/// @copydoc cTensorTranspose(const int *,const int,const float,const float *,const int *,const int *,const int *,const float,float *,
+/// const int *,const int *,const int,const int)
+void cOffsetTensorTranspose( const int *perm, const int dim,
+                 const float _Complex alpha, bool conjA, const float _Complex *A, const int *sizeA, const int *outerSizeA, const int *offsetA,
+                 const float _Complex beta,                    float _Complex *B,                   const int *outerSizeB, const int *offsetB,
+                 const int numThreads, const int useRowMajor = 0);
+
+/// @copydoc zTensorTranspose(const int *,const int,const float,const float *,const int *,const int *,const int *,const float,float *,
+/// const int *,const int *,const int,const int)
+void zOffsetTensorTranspose( const int *perm, const int dim,
+                 const double _Complex alpha, bool conjA, const double _Complex *A, const int *sizeA, const int *outerSizeA, const int *offsetA,
+                 const double _Complex beta,                    double _Complex *B,                   const int *outerSizeB, const int *offsetB,
+                 const int numThreads, const int useRowMajor = 0);
 // }

--- a/libs/Einsums/HPTT/include/Einsums/HPTT/Transpose.hpp
+++ b/libs/Einsums/HPTT/include/Einsums/HPTT/Transpose.hpp
@@ -59,11 +59,19 @@ class Transpose {
      *                       * This parameter may be NULL, indicating that the outer-size is equal to sizeA.
      *                       * If outerSizeA is not NULL, outerSizeA[i] >= sizeA[i] for all 0 <= i < dim must hold.
      *                       * This option enables HPTT to operate on sub-tensors.
+     * \param[in] offsetA dim-dimensional array that stores the offsets in each dimension of A
+     *                       * This parameter may be NULL, indicating that the offset is zero.
+     *                       * If offsetA is not NULL, outerSizeA[i] >= offsetA[i] + sizeA[i] >= 0 for all 0 <= i < dim must hold.
+     *                       * This option enables HPTT to operate on intermediate sub-tensors.
      * \param[in] beta scaling factor for B
      * \param[inout] B Pointer to the raw-data of the output tensor B
      * \param[in] outerSizeB dim-dimensional array that stores the outer-sizes of each dimension of B.
      *                       * This parameter may be NULL, indicating that the outer-size is equal to the perm(sizeA).
      *                       * If outerSizeA is not NULL, outerSizeB[i] >= perm(sizeA)[i] for all 0 <= i < dim must hold.
+     * \param[in] offsetB dim-dimensional array that stores the offsets in each dimension of B
+     *                       * This parameter may be NULL, indicating that the offset is zero.
+     *                       * If offsetB is not NULL, outerSizeB[i] >= offsetB[i] + sizeB[i] >= 0 for all 0 <= i < dim must hold.
+     *                       * This option enables HPTT to operate on intermediate sub-tensors.
      *                       * This option enables HPTT to operate on sub-tensors.
      * \param[in] selectionMethod Determines if auto-tuning should be used. See hptt::SelectionMethod for details.
      *                            ATTENTION: If you enable auto-tuning (e.g., hptt::MEASURE)
@@ -79,9 +87,9 @@ class Transpose {
      *            Column-Major: indices are stored from left to right (leftmost = stride-1 index)
      *            Row-Major: indices are stored from right to left (right = stride-1 index)
      */
-    Transpose(int const *sizeA, int const *perm, int const *outerSizeA, int const *outerSizeB, int const dim, floatType const *A,
-              floatType const alpha, floatType *B, floatType const beta, SelectionMethod const selectionMethod, int const numThreads,
-              int const *threadIds = nullptr, bool const useRowMajor = false);
+    Transpose(int const *sizeA, int const *perm, int const *outerSizeA, int const *outerSizeB, const int *offsetA, const int *offsetB,
+              int const dim, floatType const *A, floatType const alpha, floatType *B, floatType const beta, 
+              SelectionMethod const selectionMethod, int const numThreads, int const *threadIds = nullptr, bool const useRowMajor = false);
 
     /**
      * Copy construct a Transpose object.
@@ -248,7 +256,8 @@ class Transpose {
     void                  createPlans(std::vector<std::shared_ptr<Plan>> &plans) const;
     std::shared_ptr<Plan> selectPlan(std::vector<std::shared_ptr<Plan>> const &plans);
     void                  fuseIndices();
-    void                  skipIndices(int const *_sizeA, int const *_perm, int const *_outerSizeA, int const *_outerSizeB, int const dim);
+    void                  skipIndices(int const *_sizeA, int const *_perm, int const *_outerSizeA, int const *_outerSizeB, const int *_offsetA, 
+                                      const int *_offsetB, int const dim);
     void                  computeLeadingDimensions();
     double                loopCostHeuristic(std::vector<int> const &loopOrder) const;
     double                parallelismCostHeuristic(std::vector<int> const &loopOrder) const;
@@ -266,7 +275,8 @@ class Transpose {
                       std::list<int> &primeFactors, float const minBalancing, std::vector<int> const &loopsAllowed) const;
     float getLoadBalance(std::vector<int> const &parallelismStrategy) const;
     float estimateExecutionTime(std::shared_ptr<Plan> const plan); // execute just a few iterations and extrapolate the result
-    void  verifyParameter(int const *size, int const *perm, int const *outerSizeA, int const *outerSizeB, int const dim) const;
+    void  verifyParameter(int const *size, int const *perm, int const *outerSizeA, int const *outerSizeB, const int* offsetA, 
+                          const int* offsetB, int const dim) const;
     void  getBestParallelismStrategy(std::vector<int> &bestParallelismStrategy) const;
     void  getBestLoopOrder(std::vector<int> &loopOrder) const; // innermost loop idx is stored at dim_-1
     void  getLoopOrders(std::vector<std::vector<int>> &loopOrders) const;
@@ -289,6 +299,8 @@ class Transpose {
     std::vector<int>    perm_;       //!< permutation
     std::vector<size_t> outerSizeA_; //!< outer sizes of A
     std::vector<size_t> outerSizeB_; //!< outer sizes of B
+    std::vector<size_t> offsetA_;    //!< offsets of A
+    std::vector<size_t> offsetB_;    //!< offsets of B
     std::vector<size_t> lda_;        //!< strides for all dimensions of A (first dimension has a stride of 1)
     std::vector<size_t> ldb_;        //!< strides for all dimensions of B (first dimension has a stride of 1)
     std::vector<int>    threadIds_;  //!< OpenMP threadIds of the threads involed in the transposition

--- a/libs/Einsums/HPTT/include/Einsums/HPTT/Utils.hpp
+++ b/libs/Einsums/HPTT/include/Einsums/HPTT/Utils.hpp
@@ -166,6 +166,7 @@ std::uint64_t factorial(std::uint8_t n);
 /**
  * Reorders parameters to swap between row-major and column-major forms.
  */
-void accountForRowMajor(int const *sizeA, int const *outerSizeA, int const *outerSizeB, int const *perm, int *tmpSizeA, int *tmpOuterSizeA,
-                        int *tmpouterSizeB, int *tmpPerm, int const dim, bool const useRowMajor);
+void accountForRowMajor(int const *sizeA, int const *outerSizeA, int const *outerSizeB, const int *offsetA, const int *offsetB, int const *perm,
+                        int *tmpSizeA, int *tmpOuterSizeA, int *tmpouterSizeB, int *tmpOffsetA, int *tmpOffsetB, int *tmpPerm, int const dim, 
+                        bool const useRowMajor);
 } // namespace hptt

--- a/libs/Einsums/HPTT/src/HPTT.cpp
+++ b/libs/Einsums/HPTT/src/HPTT.cpp
@@ -17,8 +17,8 @@ create_plan(const int *perm, const int dim, const float alpha, const float *A,
             const int numThreads, const int *threadIds,
             const bool useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<float>>(
-      sizeA, perm, outerSizeA, outerSizeB, dim, A, alpha, B, beta,
-      selectionMethod, numThreads, threadIds, useRowMajor));
+      sizeA, perm, outerSizeA, outerSizeB, nullptr, nullptr, dim, A, alpha, 
+      B, beta, selectionMethod, numThreads, threadIds, useRowMajor));
   return plan;
 }
 
@@ -29,8 +29,8 @@ create_plan(const int *perm, const int dim, const double alpha, const double *A,
             const SelectionMethod selectionMethod, const int numThreads,
             const int *threadIds, const bool useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<double>>(
-      sizeA, perm, outerSizeA, outerSizeB, dim, A, alpha, B, beta,
-      selectionMethod, numThreads, threadIds, useRowMajor));
+      sizeA, perm, outerSizeA, outerSizeB, nullptr, nullptr, dim, A, alpha, 
+      B, beta, selectionMethod, numThreads, threadIds, useRowMajor));
   return plan;
 }
 
@@ -41,8 +41,8 @@ create_plan(const int *perm, const int dim, const FloatComplex alpha,
             const SelectionMethod selectionMethod, const int numThreads,
             const int *threadIds, const bool useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<FloatComplex>>(
-      sizeA, perm, outerSizeA, outerSizeB, dim, A, alpha, B, beta,
-      selectionMethod, numThreads, threadIds, useRowMajor));
+      sizeA, perm, outerSizeA, outerSizeB, nullptr, nullptr, dim, A, alpha, 
+      B, beta, selectionMethod, numThreads, threadIds, useRowMajor));
   return plan;
 }
 
@@ -53,8 +53,8 @@ create_plan(const int *perm, const int dim, const DoubleComplex alpha,
             const SelectionMethod selectionMethod, const int numThreads,
             const int *threadIds, const bool useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<DoubleComplex>>(
-      sizeA, perm, outerSizeA, outerSizeB, dim, A, alpha, B, beta,
-      selectionMethod, numThreads, threadIds, useRowMajor));
+      sizeA, perm, outerSizeA, outerSizeB, nullptr, nullptr, dim, A, alpha, 
+      B, beta, selectionMethod, numThreads, threadIds, useRowMajor));
   return plan;
 }
 
@@ -66,8 +66,8 @@ create_plan(const std::vector<int> &perm, const int dim, const float alpha,
             const SelectionMethod selectionMethod, const int numThreads,
             const std::vector<int> &threadIds, const bool useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<float>>(
-      &sizeA[0], &perm[0], &outerSizeA[0], &outerSizeB[0], dim, A, alpha, B,
-      beta, selectionMethod, numThreads,
+      &sizeA[0], &perm[0], &outerSizeA[0], &outerSizeB[0], nullptr, nullptr, 
+      dim, A, alpha, B, beta, selectionMethod, numThreads,
       (threadIds.size() > 0) ? &threadIds[0] : nullptr, useRowMajor));
   return plan;
 }
@@ -80,8 +80,8 @@ create_plan(const std::vector<int> &perm, const int dim, const double alpha,
             const SelectionMethod selectionMethod, const int numThreads,
             const std::vector<int> &threadIds, const bool useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<double>>(
-      &sizeA[0], &perm[0], &outerSizeA[0], &outerSizeB[0], dim, A, alpha, B,
-      beta, selectionMethod, numThreads,
+      &sizeA[0], &perm[0], &outerSizeA[0], &outerSizeB[0], nullptr, nullptr, 
+      dim, A, alpha, B, beta, selectionMethod, numThreads,
       (threadIds.size() > 0) ? &threadIds[0] : nullptr, useRowMajor));
   return plan;
 }
@@ -95,8 +95,8 @@ create_plan(const std::vector<int> &perm, const int dim,
             const SelectionMethod selectionMethod, const int numThreads,
             const std::vector<int> &threadIds, const bool useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<FloatComplex>>(
-      &sizeA[0], &perm[0], &outerSizeA[0], &outerSizeB[0], dim, A, alpha, B,
-      beta, selectionMethod, numThreads,
+      &sizeA[0], &perm[0], &outerSizeA[0], &outerSizeB[0], nullptr, nullptr, 
+      dim, A, alpha, B, beta, selectionMethod, numThreads,
       (threadIds.size() > 0) ? &threadIds[0] : nullptr, useRowMajor));
   return plan;
 }
@@ -110,8 +110,8 @@ create_plan(const std::vector<int> &perm, const int dim,
             const SelectionMethod selectionMethod, const int numThreads,
             const std::vector<int> &threadIds, const bool useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<DoubleComplex>>(
-      &sizeA[0], &perm[0], &outerSizeA[0], &outerSizeB[0], dim, A, alpha, B,
-      beta, selectionMethod, numThreads,
+      &sizeA[0], &perm[0], &outerSizeA[0], &outerSizeB[0], nullptr, nullptr, 
+      dim, A, alpha, B, beta, selectionMethod, numThreads,
       (threadIds.size() > 0) ? &threadIds[0] : nullptr, useRowMajor));
   return plan;
 }
@@ -123,8 +123,8 @@ create_plan(const int *perm, const int dim, const float alpha, const float *A,
             const int numThreads, const int *threadIds,
             const bool useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<float>>(
-      sizeA, perm, outerSizeA, outerSizeB, dim, A, alpha, B, beta, MEASURE,
-      numThreads, threadIds, useRowMajor));
+      sizeA, perm, outerSizeA, outerSizeB, nullptr, nullptr, dim, A, alpha, 
+      B, beta, MEASURE, numThreads, threadIds, useRowMajor));
   plan->setMaxAutotuningCandidates(maxAutotuningCandidates);
   plan->createPlan();
   return plan;
@@ -137,8 +137,8 @@ create_plan(const int *perm, const int dim, const double alpha, const double *A,
             const int numThreads, const int *threadIds,
             const bool useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<double>>(
-      sizeA, perm, outerSizeA, outerSizeB, dim, A, alpha, B, beta, MEASURE,
-      numThreads, threadIds, useRowMajor));
+      sizeA, perm, outerSizeA, outerSizeB, nullptr, nullptr, dim, A, alpha, 
+      B, beta, MEASURE, numThreads, threadIds, useRowMajor));
   plan->setMaxAutotuningCandidates(maxAutotuningCandidates);
   plan->createPlan();
   return plan;
@@ -151,8 +151,8 @@ create_plan(const int *perm, const int dim, const FloatComplex alpha,
             const int maxAutotuningCandidates, const int numThreads,
             const int *threadIds, const bool useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<FloatComplex>>(
-      sizeA, perm, outerSizeA, outerSizeB, dim, A, alpha, B, beta, MEASURE,
-      numThreads, threadIds, useRowMajor));
+      sizeA, perm, outerSizeA, outerSizeB, nullptr, nullptr, dim, A, alpha, 
+      B, beta, MEASURE, numThreads, threadIds, useRowMajor));
   plan->createPlan();
   return plan;
 }
@@ -164,12 +164,188 @@ create_plan(const int *perm, const int dim, const DoubleComplex alpha,
             const int maxAutotuningCandidates, const int numThreads,
             const int *threadIds, const bool useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<DoubleComplex>>(
-      sizeA, perm, outerSizeA, outerSizeB, dim, A, alpha, B, beta, MEASURE,
-      numThreads, threadIds, useRowMajor));
+      sizeA, perm, outerSizeA, outerSizeB, nullptr, nullptr, dim, A, 
+      alpha, B, beta, MEASURE, numThreads, threadIds, useRowMajor));
   plan->setMaxAutotuningCandidates(maxAutotuningCandidates);
   plan->createPlan();
   return plan;
 }
+
+/* Methods with (floats, doubles, FloatComplexes, and DoubleComplexes) (alpha, A, beta, and B), SelectionMethod Class, 
+ * --int-- Offsets, and ints (sizeA, outerSizeA, and outerSizeB). */
+std::shared_ptr<hptt::Transpose<float>> 
+create_plan(const int *perm, const int dim, const float alpha, const float *A, const int *sizeA, 
+            const int *outerSizeA, const int *offsetA, const float beta, float *B, 
+            const int *outerSizeB, const int *offsetB, const SelectionMethod selectionMethod,
+            const int numThreads, const int *threadIds, const bool useRowMajor)
+{
+   auto plan(std::make_shared<hptt::Transpose<float>>(
+       sizeA, perm, outerSizeA, outerSizeB, offsetA, offsetB, dim, A, alpha, 
+       B, beta, selectionMethod, numThreads, threadIds, useRowMajor));
+   return plan;
+}
+
+std::shared_ptr<hptt::Transpose<double>> 
+create_plan(const int *perm, const int dim, const double alpha, const double *A, const int *sizeA, 
+            const int *outerSizeA, const int *offsetA, const double beta, double *B, 
+            const int *outerSizeB, const int *offsetB, const SelectionMethod selectionMethod,
+            const int numThreads, const int *threadIds, const bool useRowMajor)
+{
+   auto plan(std::make_shared<hptt::Transpose<double>>(
+       sizeA, perm, outerSizeA, outerSizeB, offsetA, offsetB, dim, A, alpha, 
+       B, beta, selectionMethod, numThreads, threadIds, useRowMajor));
+   return plan;
+}
+
+std::shared_ptr<hptt::Transpose<FloatComplex>> 
+create_plan(const int *perm, const int dim, const FloatComplex alpha, const FloatComplex *A, 
+            const int *sizeA, const int *outerSizeA, const int *offsetA,
+            const FloatComplex beta, FloatComplex *B, const int *outerSizeB, const int *offsetB,
+            const SelectionMethod selectionMethod, const int numThreads, const int *threadIds, 
+            const bool useRowMajor)
+{
+   auto plan(std::make_shared<hptt::Transpose<FloatComplex>>(
+       sizeA, perm, outerSizeA, outerSizeB, offsetA, offsetB, dim, A, alpha, 
+       B, beta, selectionMethod, numThreads, threadIds, useRowMajor));
+   return plan;
+}
+
+std::shared_ptr<hptt::Transpose<DoubleComplex>> 
+create_plan(const int *perm, const int dim, const DoubleComplex alpha, const DoubleComplex *A, 
+            const int *sizeA, const int *outerSizeA, const int *offsetA, const DoubleComplex beta, 
+            DoubleComplex *B, const int *outerSizeB, const int *offsetB, 
+            const SelectionMethod selectionMethod, const int numThreads, const int *threadIds, 
+            const bool useRowMajor)
+{
+   auto plan(std::make_shared<hptt::Transpose<DoubleComplex>>(
+       sizeA, perm, outerSizeA, outerSizeB, offsetA, offsetB, dim, A, alpha, 
+       B, beta, selectionMethod, numThreads, threadIds, useRowMajor));
+   return plan;
+}
+
+/* Methods with (floats, doubles, FloatComplexes, and DoubleComplexes) (alpha, A, beta, and B), SelectionMethod Class, 
+ * --vector int-- Offsets, and vector ints (sizeA, outerSizeA, and outerSizeB). */
+std::shared_ptr<hptt::Transpose<float>> 
+create_plan(const std::vector<int> &perm, const int dim, const float alpha, 
+            const float *A, const std::vector<int> &sizeA, const std::vector<int> &outerSizeA, 
+            const std::vector<int> &offsetA, const float beta, float *B, 
+            const std::vector<int> &outerSizeB, const std::vector<int> &offsetB,
+            const SelectionMethod selectionMethod,
+            const int numThreads, const std::vector<int> &threadIds, const bool useRowMajor)
+{
+   auto plan(std::make_shared<hptt::Transpose<float>>(
+       &sizeA[0], &perm[0], &outerSizeA[0], &outerSizeB[0], &offsetA[0], 
+       &offsetB[0], dim, A, alpha, B, beta, selectionMethod, numThreads, 
+       (threadIds.size() > 0 ) ? &threadIds[0] : nullptr, useRowMajor ));
+   return plan;
+}
+
+std::shared_ptr<hptt::Transpose<double>> 
+create_plan(const std::vector<int> &perm, const int dim, const double alpha, 
+            const double *A, const std::vector<int> &sizeA, const std::vector<int> &outerSizeA, 
+            const std::vector<int> &offsetA, const double beta, double *B, 
+            const std::vector<int> &outerSizeB, const std::vector<int> &offsetB,
+            const SelectionMethod selectionMethod,
+            const int numThreads, const std::vector<int> &threadIds, const bool useRowMajor)
+{
+   auto plan(std::make_shared<hptt::Transpose<double>>(
+       &sizeA[0], &perm[0], &outerSizeA[0], &outerSizeB[0], &offsetA[0], 
+       &offsetB[0], dim, A, alpha, B, beta, selectionMethod, numThreads, 
+       (threadIds.size() > 0 ) ? &threadIds[0] : nullptr, useRowMajor));
+   return plan;
+}
+
+std::shared_ptr<hptt::Transpose<FloatComplex>> 
+create_plan(const std::vector<int> &perm, const int dim, const FloatComplex alpha, 
+            const FloatComplex *A, const std::vector<int> &sizeA, const std::vector<int> &outerSizeA, 
+            const std::vector<int> &offsetA, const FloatComplex beta, FloatComplex *B, 
+            const std::vector<int> &outerSizeB, const std::vector<int> &offsetB,
+            const SelectionMethod selectionMethod, const int numThreads, 
+            const std::vector<int> &threadIds, const bool useRowMajor)
+{
+   auto plan(std::make_shared<hptt::Transpose<FloatComplex>>(
+       &sizeA[0], &perm[0], &outerSizeA[0], &outerSizeB[0], &offsetA[0], 
+       &offsetB[0], dim, A, alpha, B, beta, selectionMethod, numThreads, 
+       (threadIds.size() > 0 ) ? &threadIds[0] : nullptr, useRowMajor));
+   return plan;
+}
+
+std::shared_ptr<hptt::Transpose<DoubleComplex>> 
+create_plan(const std::vector<int> &perm, const int dim, const DoubleComplex alpha, 
+            const DoubleComplex *A, const std::vector<int> &sizeA, const std::vector<int> &outerSizeA, 
+            const std::vector<int> &offsetA, const DoubleComplex beta, DoubleComplex *B, 
+            const std::vector<int> &outerSizeB, const std::vector<int> &offsetB,
+            const SelectionMethod selectionMethod, const int numThreads, 
+            const std::vector<int> &threadIds, const bool useRowMajor)
+{
+   auto plan(std::make_shared<hptt::Transpose<DoubleComplex>>(
+       &sizeA[0], &perm[0], &outerSizeA[0], &outerSizeB[0], &offsetA[0], 
+       &offsetB[0], dim, A, alpha, B, beta, selectionMethod, numThreads, 
+       (threadIds.size() > 0 ) ? &threadIds[0] : nullptr, useRowMajor));
+   return plan;
+}
+
+/* Methods with (floats, doubles, FloatComplexes, and DoubleComplexes) (alpha, A, beta, and B), --int-- maxAutotuningCandidates, 
+ * --int-- Offsets, and ints (sizeA, outerSizeA, and outerSizeB). */
+std::shared_ptr<hptt::Transpose<float>> 
+create_plan(const int *perm, const int dim, const float alpha, 
+            const float *A, const int *sizeA, const int *outerSizeA, const int *offsetA,
+            const float beta, float *B, const int *outerSizeB, const int *offsetB,
+            const int maxAutotuningCandidates, const int numThreads, const int *threadIds, 
+            const bool useRowMajor)
+{
+   auto plan(std::make_shared<hptt::Transpose<float>>(
+       sizeA, perm, outerSizeA, outerSizeB, offsetA, offsetB, dim, A, 
+       alpha, B, beta, MEASURE, numThreads, threadIds, useRowMajor));
+   plan->setMaxAutotuningCandidates(maxAutotuningCandidates);
+   plan->createPlan();
+   return plan;
+}
+
+std::shared_ptr<hptt::Transpose<double>> 
+create_plan(const int *perm, const int dim, const double alpha, 
+            const double *A, const int *sizeA, const int *outerSizeA, const int *offsetA,
+            const double beta, double *B, const int *outerSizeB, const int *offsetB,
+            const int maxAutotuningCandidates, const int numThreads, const int *threadIds, 
+            const bool useRowMajor)
+{
+   auto plan(std::make_shared<hptt::Transpose<double>>(
+       sizeA, perm, outerSizeA, outerSizeB, offsetA, offsetB, dim, A, 
+       alpha, B, beta, MEASURE, numThreads, threadIds, useRowMajor));
+   plan->setMaxAutotuningCandidates(maxAutotuningCandidates);
+   plan->createPlan();
+   return plan;
+}
+
+std::shared_ptr<hptt::Transpose<FloatComplex> > 
+create_plan(const int *perm, const int dim, const FloatComplex alpha, 
+            const FloatComplex *A, const int *sizeA, const int *outerSizeA, const int *offsetA,
+            const FloatComplex beta, FloatComplex *B, const int *outerSizeB, const int *offsetB,
+            const int maxAutotuningCandidates, const int numThreads, const int *threadIds, 
+            const bool useRowMajor)
+{
+   auto plan(std::make_shared<hptt::Transpose<FloatComplex>>(
+       sizeA, perm, outerSizeA, outerSizeB, offsetA, offsetB, dim, A, 
+       alpha, B, beta, MEASURE, numThreads, threadIds, useRowMajor));
+   plan->createPlan();
+   return plan;
+}
+
+std::shared_ptr<hptt::Transpose<DoubleComplex>> 
+create_plan(const int *perm, const int dim, const DoubleComplex alpha, 
+            const DoubleComplex *A, const int *sizeA, const int *outerSizeA, const int *offsetA,
+            const DoubleComplex beta, DoubleComplex *B, const int *outerSizeB, const int *offsetB,
+            const int maxAutotuningCandidates, const int numThreads, const int *threadIds, 
+            const bool useRowMajor)
+{
+   auto plan(std::make_shared<hptt::Transpose<DoubleComplex>>(
+       sizeA, perm, outerSizeA, outerSizeB, offsetA, offsetB, dim, A, 
+       alpha, B, beta, MEASURE, numThreads, threadIds, useRowMajor));
+   plan->setMaxAutotuningCandidates(maxAutotuningCandidates);
+   plan->createPlan();
+   return plan;
+}
+
 } // namespace hptt
 
 #if 0
@@ -179,8 +355,8 @@ void sTensorTranspose(const int *perm, const int dim, const float alpha,
                       const float beta, float *B, const int *outerSizeB,
                       const int numThreads, const int useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<float>>(
-      sizeA, perm, outerSizeA, outerSizeB, dim, A, alpha, B, beta,
-      hptt::ESTIMATE, numThreads, nullptr, useRowMajor));
+      sizeA, perm, outerSizeA, outerSizeB, nullptr, nullptr, dim, A, 
+      alpha, B, beta, hptt::ESTIMATE, numThreads, nullptr, useRowMajor));
   plan->execute();
 }
 
@@ -189,8 +365,8 @@ void dTensorTranspose(const int *perm, const int dim, const double alpha,
                       const double beta, double *B, const int *outerSizeB,
                       const int numThreads, const int useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<double>>(
-      sizeA, perm, outerSizeA, outerSizeB, dim, A, alpha, B, beta,
-      hptt::ESTIMATE, numThreads, nullptr, useRowMajor));
+      sizeA, perm, outerSizeA, outerSizeB, nullptr, nullptr, dim, A, 
+      alpha, B, beta, hptt::ESTIMATE, numThreads, nullptr, useRowMajor));
   plan->execute();
 }
 
@@ -201,10 +377,10 @@ void cTensorTranspose(const int *perm, const int dim,
                       float _Complex *B, const int *outerSizeB,
                       const int numThreads, const int useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<hptt::FloatComplex>>(
-      sizeA, perm, outerSizeA, outerSizeB, dim, (const hptt::FloatComplex *)A,
-      (hptt::FloatComplex)alpha, (hptt::FloatComplex *)B,
-      (hptt::FloatComplex)beta, hptt::ESTIMATE, numThreads, nullptr,
-      useRowMajor));
+      sizeA, perm, outerSizeA, outerSizeB, nullptr, nullptr, dim, 
+      (const hptt::FloatComplex *)A, (hptt::FloatComplex)alpha, 
+      (hptt::FloatComplex *)B, (hptt::FloatComplex)beta, hptt::ESTIMATE, 
+      numThreads, nullptr, useRowMajor));
   plan->setConjA(conjA);
   plan->execute();
 }
@@ -216,10 +392,63 @@ void zTensorTranspose(const int *perm, const int dim,
                       double _Complex *B, const int *outerSizeB,
                       const int numThreads, const int useRowMajor) {
   auto plan(std::make_shared<hptt::Transpose<hptt::DoubleComplex>>(
-      sizeA, perm, outerSizeA, outerSizeB, dim, (const hptt::DoubleComplex *)A,
-      (hptt::DoubleComplex)alpha, (hptt::DoubleComplex *)B,
-      (hptt::DoubleComplex)beta, hptt::ESTIMATE, numThreads, nullptr,
-      useRowMajor));
+      sizeA, perm, outerSizeA, outerSizeB, nullptr, nullptr, dim, 
+      (const hptt::DoubleComplex *)A, (hptt::DoubleComplex)alpha, 
+      (hptt::DoubleComplex *)B, (hptt::DoubleComplex)beta, hptt::ESTIMATE, 
+      numThreads, nullptr, useRowMajor));
+  plan->setConjA(conjA);
+  plan->execute();
+}
+
+/* With Offset */
+void sOffsetTensorTranspose(const int *perm, const int dim, const float alpha, 
+                            const float *A, const int *sizeA, const int *outerSizeA, const int *offsetA,
+                            const float beta, float *B, const int *outerSizeB, const int *offsetB,
+                            const int numThreads, const int useRowMajor)
+{
+  auto plan(std::make_shared<hptt::Transpose<float> >(
+      sizeA, perm, outerSizeA, outerSizeB, offsetA, offsetB, dim, A, alpha, 
+      B, beta, hptt::ESTIMATE, numThreads, nullptr, useRowMajor));
+  plan->execute();
+}
+
+void dOffsetTensorTranspose(const int *perm, const int dim, const double alpha, 
+                            const double *A, const int *sizeA, const int *outerSizeA, const int *offsetA, 
+                            const double beta, double *B, const int *outerSizeB, const int *offsetB,
+                            const int numThreads, const int useRowMajor)
+{
+  auto plan(std::make_shared<hptt::Transpose<double> >(
+      sizeA, perm, outerSizeA, outerSizeB, offsetA, offsetB, dim, A, alpha, 
+      B, beta, hptt::ESTIMATE, numThreads, nullptr, useRowMajor));
+  plan->execute();
+}
+
+void cOffsetTensorTranspose(const int *perm, const int dim,
+                            const float _Complex alpha, bool conjA, 
+                            const float _Complex *A, const int *sizeA, const int *outerSizeA, const int *offsetA, 
+                            const float _Complex beta, float _Complex *B, const int *outerSizeB, const int *offsetB,
+                            const int numThreads, const int useRowMajor)
+{
+  auto plan(std::make_shared<hptt::Transpose<hptt::FloatComplex> >(
+      sizeA, perm, outerSizeA, outerSizeB, offsetA, offsetB, dim, 
+      (const hptt::FloatComplex*) A, (hptt::FloatComplex)(__real__ alpha, __imag__ alpha), 
+      (hptt::FloatComplex*) B, (hptt::FloatComplex)(__real__ beta, __imag__ beta), 
+      hptt::ESTIMATE, numThreads, nullptr, useRowMajor));
+  plan->setConjA(conjA);
+  plan->execute();
+}
+
+void zOffsetTensorTranspose(const int *perm, const int dim,
+                            const double _Complex alpha, bool conjA, 
+                            const double _Complex *A, const int *sizeA, const int *outerSizeA, const int *offsetA, 
+                            const double _Complex beta, double _Complex *B, const int *outerSizeB, const int *offsetB,
+                            const int numThreads, const int useRowMajor)
+{
+  auto plan(std::make_shared<hptt::Transpose<hptt::DoubleComplex> >(
+      sizeA, perm, outerSizeA, outerSizeB, offsetA, offsetB, dim, 
+      (const hptt::DoubleComplex*) A, (hptt::DoubleComplex)(__real__ alpha, __imag__ alpha), 
+      (hptt::DoubleComplex*) B, (hptt::DoubleComplex)(__real__ beta, __imag__ beta), 
+      hptt::ESTIMATE, numThreads, nullptr, useRowMajor));
   plan->setConjA(conjA);
   plan->execute();
 }

--- a/libs/Einsums/HPTT/src/Utils.cpp
+++ b/libs/Einsums/HPTT/src/Utils.cpp
@@ -364,8 +364,9 @@ uint64_t factorial(uint8_t n) {
     }
 }
 
-void accountForRowMajor(int const *sizeA, int const *outerSizeA, int const *outerSizeB, int const *perm, int *tmpSizeA, int *tmpOuterSizeA,
-                        int *tmpOuterSizeB, int *tmpPerm, int const dim, bool const useRowMajor) {
+void accountForRowMajor(int const *sizeA, int const *outerSizeA, int const *outerSizeB, const int *offsetA, const int *offsetB, 
+                        int const *perm, int *tmpSizeA, int *tmpOuterSizeA, int *tmpOuterSizeB, int *tmpOffsetA, int *tmpOffsetB, 
+                        int *tmpPerm, int const dim, bool const useRowMajor) {
     for (int i = 0; i < dim; ++i) {
         int idx = i;
         if (useRowMajor) {
@@ -383,6 +384,14 @@ void accountForRowMajor(int const *sizeA, int const *outerSizeA, int const *oute
             tmpOuterSizeB[i] = sizeA[perm[idx]];
         else
             tmpOuterSizeB[i] = outerSizeB[idx];
+        if( offsetA == nullptr )
+            tmpOffsetA[i] = 0;
+        else
+            tmpOffsetA[i] = offsetA[idx];
+        if( offsetB == nullptr )
+            tmpOffsetB[i] = 0;
+        else
+            tmpOffsetB[i] = offsetB[idx];
     }
 }
 

--- a/libs/Einsums/TensorAlgebra/src/Permute.cpp
+++ b/libs/Einsums/TensorAlgebra/src/Permute.cpp
@@ -44,6 +44,40 @@ void permute(int const *perm, int const dim, std::complex<double> const alpha, s
     plan->execute();
 }
 
+void permute(int const *perm, int const dim, float const alpha, float const *A, int const *sizeA, int const *offsetA, int const *outerSizeA,
+             float const beta, float *B, int const *offsetB,  int const *outerSizeB) {
+    auto plan =
+        hptt::create_plan(perm, dim, alpha, A, sizeA, outerSizeA, offsetA, beta, B, outerSizeB, offsetB, hptt::ESTIMATE, omp_get_max_threads(),
+                          nullptr, true);
+    plan->execute();
+}
+
+void permute(int const *perm, int const dim, double const alpha, double const *A, int const *sizeA, int const *offsetA, int const *outerSizeA,
+             double const beta, double *B, int const *offsetB,  int const *outerSizeB) {
+    auto plan =
+        hptt::create_plan(perm, dim, alpha, A, sizeA, outerSizeA, offsetA, beta, B, outerSizeB, offsetB, hptt::ESTIMATE, omp_get_max_threads(),
+                          nullptr, true);
+    plan->execute();
+}
+
+void permute(int const *perm, int const dim, std::complex<float> const alpha, std::complex<float> const *A, int const *sizeA,
+             int const *offsetA, int const *outerSizeA, std::complex<float> const beta, std::complex<float> *B, int const *offsetB,
+             int const *outerSizeB) {
+    auto plan =
+        hptt::create_plan(perm, dim, alpha, A, sizeA, outerSizeA, offsetA, beta, B, outerSizeB, offsetB, hptt::ESTIMATE, omp_get_max_threads(),
+                          nullptr, true);
+    plan->execute();
+}
+
+void permute(int const *perm, int const dim, std::complex<double> const alpha, std::complex<double> const *A, int const *sizeA,
+             int const *offsetA, int const *outerSizeA, std::complex<double> const beta, std::complex<double> *B, int const *offsetB,
+             int const *outerSizeB) {
+    auto plan =
+        hptt::create_plan(perm, dim, alpha, A, sizeA, outerSizeA, offsetA, beta, B, outerSizeB, offsetB, hptt::ESTIMATE, omp_get_max_threads(),
+                          nullptr, true);
+    plan->execute();
+}
+
 } // namespace einsums::tensor_algebra::detail
 
 #endif

--- a/libs/Einsums/TensorAlgebra/tests/unit/Sort.cpp
+++ b/libs/Einsums/TensorAlgebra/tests/unit/Sort.cpp
@@ -39,6 +39,7 @@ TEMPLATE_TEST_CASE("permute2", "[tensor]", float, double, std::complex<float>, s
 
         for (int i = 0, ij = 1; i < 3; i++) {
             for (int j = 0; j < 3; j++, ij++) {
+                printf("%d, %d, %d, %e, %e, %e", i, j, ij, A(i, j), C(i, j), C(j, i));
                 if (i == 0 || j == 0)
                     REQUIRE(C(i, j) == A(i, j));
                 else


### PR DESCRIPTION
FEAT: Extended the use of HPTT to SubTensors following my recent pull request on the HPTT repository. Changes to HPTT are outlined with that commit. Below are changes specific to Einsums. The changes provide a significant computational speedup of the permute function.

*libs/Einsums/HPTT/include/Einsums/HPTT*
Made changes (in alignment with Einsums formatting) to mirror those made to HPTT for their repository enabling the provision of offsets.

*libs/Einsums/Tensor/include/Einsums/Tensor/Tensor.hpp* Changes were made to the TensorView class to support the format required by HPTT.

1) `_data` is supplied as provided by the **source** Tensor except where offsets in dimensions of size == 1 are given, which are used to offset the pointer. This ensures the object supplied to HPTT is the expected size, particularly important in the case offset + size < outer size for any dimension. No breaking change as access in existing functions is provided with the offset at time of access. Only if full data is requested does the offset not get inserted.

2) `_source_dims` are recorded as the provided Tensor's dimensions. This enables outerSizes to be provided. They are calculated via _strides and sizeof(_data) if no Tensor object is provided.

3) `_offsets` are reinstated and are generally defaulted to zero unless set.

4) `_offset_ordinal` monitors the size of the initial offset of non-unitary dimensions and is supplied to any data access.

5) Methods to access full `_data`, `_source_dims`, and `_offsets` are provided.

*libs/Einsums/TensorAlgebra/include/Einsums/TensorAlgebra/Permute.hpp* Provides a new route for any Tensor or TensorView (as long as minimum stride is 1) to access a HPTT permutation setting defaults in the case of Tensor and TensorView mixed provision. Templates for permute functions are also provided.

*libs/Einsums/TensorAlgebra/src/Permute.cpp*
New functions with offsets and outerSizes are provided for the permute function so that they can supply HPTT appropriately.